### PR TITLE
4d

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A MATLAB algorithm for volumetric mesh parameterization. Developed for mapping a
 Add the MATLAB packages to the working path.
 
 ### Usage
-main(grayImage, segImage): input a grayscale MRI image and the corresponding binary segmentation, where voxels labeled '1' correspond to the placenta. The inputs grayImage, segImage can either be full path locations of NIFTI image files, or image matrices. The script outputs the flattened meshes and images containing the mapped intensities.
+main(grayImage, segImage): input a grayscale MRI image and the corresponding binary segmentation, where voxels labeled '1' correspond to the placenta. The inputs grayImage, segImage can either be full path locations of NIFTI image files, or image matrices. The grayImage input can be a 3D MRI volume, or a 4D series of MRI volumes. The script outputs the flattened meshes and images containing the mapped intensities.
 
 ### Development
 Please contact Mazdak Abulnaga, abulnaga@mit.edu.

--- a/src/main.m
+++ b/src/main.m
@@ -108,8 +108,18 @@ save([savePath,'/startVolume'],'startVolume','-v7.3');
 save([savePath,'/mappedVolume'],'mappedVolume','-v7.3');
 fprintf('Mapping MRI image to flattened space...\n');
 
-%map the MRI intensity values to the flattened space
-[mappedImage, Tflat] = map_intensity_3d(double(grayImage), startVolume, mappedVolume);
+
+%map the MRI intensity values to the flattened space 
+dims = size(grayImage);
+if length(dims)==3 || dims(4)==1 %image is 3D or 4th dimension is singular
+    [mappedImage, Tflat] = map_intensity_3d(double(grayImage), startVolume, mappedVolume);
+elseif dims(4)>1 %image is 4D - map the intesity values by looping over volumes
+    mappedImage = zeros(dims);
+    for i=1:dims(4) 
+        [mappedImage(:,:,:,i), Tflat] = map_intensity_3d(double(grayImage(:,:,:,i)), startVolume, mappedVolume);
+    end         
+end
+
 
 %save the mapped images as NIFTI files if NIFTI files were input to the
 %algorithm. Always saves outputs as matlab matrices.


### PR DESCRIPTION
Now accepts 4D input grayscale images as input. Implemented by adding a loop when mapping the MRI images to the flattened space. I've tested with 4D nifti input, but not 4D image matrices.